### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,7 +4,14 @@
         "default": {
             "runner": "@nx/workspace/tasks-runners/default",
             "options": {
-                "cacheableOperations": ["build", "test", "test:eslint", "package", "prepare", "build:travis"]
+                "cacheableOperations": [
+                    "build",
+                    "test",
+                    "test:eslint",
+                    "package",
+                    "prepare",
+                    "build:travis"
+                ]
             }
         }
     },
@@ -35,5 +42,6 @@
         "@nx/js": {
             "analyzeSourceFiles": false
         }
-    }
+    },
+    "nxCloudId": "67b49f9e6daf79dccebf6913"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/67b49f406daf79dccebf690f/workspaces/67b49f9e6daf79dccebf6913

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.